### PR TITLE
Don't export <linux/if.h>

### DIFF
--- a/include/netlink/route/link.h
+++ b/include/netlink/route/link.h
@@ -15,7 +15,7 @@
 #include <netlink/netlink.h>
 #include <netlink/cache.h>
 #include <netlink/addr.h>
-#include <linux/if.h>
+#include <net/if.h>
 #include <sys/types.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
Many linux headers conflict with libc headers and are not really intended to be used by user space. In particular, <linux/if.h> conflicts with <net/if.h>. Change the libnl headers to use <net/if.h>.If this change is applied bmon's in_netlink.c needs to be fixed accordingly.