### PR TITLE
lib/nl: Increase default receive socket buffer size to 128k

### DIFF
--- a/lib/nl.c
+++ b/lib/nl.c
@@ -122,7 +122,7 @@ int nl_connect(struct nl_sock *sk, int protocol)
 		goto errout;
 	}
 
-	err = nl_socket_set_buffer_size(sk, 0, 0);
+	err = nl_socket_set_buffer_size(sk, 131702, 0);
 	if (err < 0)
 		goto errout;
 


### PR DESCRIPTION
This patch set default receive socket buffer size to 128K to solve
nl_recv returned with error: No buffer space available
1. When switching CPUs to offline/online in a system more than 128 cpus
2. When using virsh to destroy domain in a system with more interfaces
3. When NetworkMananger monitoring some uevents,e.g. netlink is changed.

Signed-off-by: Leno Hou houqy@linux.vnet.ibm.com
