### PR TITLE
lib: add type casting for nla_for_each_nested macro

### DIFF
--- a/include/netlink/attr.h
+++ b/include/netlink/attr.h
@@ -274,7 +274,7 @@ extern int		nla_is_nested(const struct nlattr *);
  * @arg rem	initialized to len, holds bytes currently remaining in stream
  */
 #define nla_for_each_nested(pos, nla, rem) \
-	for (pos = nla_data(nla), rem = nla_len(nla); \
+	for (pos = (struct nlattr *) nla_data(nla), rem = nla_len(nla); \
 	     nla_ok(pos, rem); \
 	     pos = nla_next(pos, &(rem)))
 


### PR DESCRIPTION
g++ is unable to compile code with nla_for_each_nested macro due to
implicit type conversion from void* to nlattr*. This patch adds type
casting for nla_for_each_nested macro to address this issue.

Signed-off-by: Przemyslaw Szczerbik <przemek.szczerbik@gmail.com>