### PR TITLE
Include <sys/select.h> before calling select(2)

### DIFF
--- a/src/nf-log.c
+++ b/src/nf-log.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2007 Secure Computing Corporation
  */
 
+#include <sys/select.h>
 #include <netlink/cli/utils.h>
 #include <netlink/cli/link.h>
 #include <linux/netfilter/nfnetlink_log.h>

--- a/src/nf-monitor.c
+++ b/src/nf-monitor.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2007 Secure Computing Corporation
  */
 
+#include <sys/select.h>
 #include <netlink/cli/utils.h>
 #include <netlink/netfilter/nfnl.h>
 

--- a/src/nf-queue.c
+++ b/src/nf-queue.c
@@ -11,6 +11,7 @@
  */
 
 
+#include <sys/select.h>
 #include <netlink/cli/utils.h>
 #include <netlink/cli/link.h>
 #include <netinet/in.h>

--- a/src/nl-monitor.c
+++ b/src/nl-monitor.c
@@ -9,6 +9,7 @@
  * Copyright (c) 2003-2009 Thomas Graf <tgraf@suug.ch>
  */
 
+#include <sys/select.h>
 #include <netlink/cli/utils.h>
 #include <netlink/cli/link.h>
 


### PR DESCRIPTION
This is needed for Android where select(2) is not defined as a side effect of including any of the other headers, and should be the correct portable thing to do to not rely on implementation details.

This came up as an issue when packaging libnl (and bmon) for [Termux](https://termux.com/), where it now is available. Patch created by @vaites in https://github.com/termux/termux-packages/pull/758.