### PR TITLE
Correct interface values for CAN attributes. CAN FD support.

### DIFF
--- a/include/linux-private/linux/can/netlink.h
+++ b/include/linux-private/linux/can/netlink.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only WITH Linux-syscall-note */
 /*
  * linux/can/netlink.h
  *
@@ -5,10 +6,18 @@
  *
  * Copyright (c) 2009 Wolfgang Grandegger <wg@grandegger.com>
  *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the version 2 of the GNU General Public License
+ * as published by the Free Software Foundation
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
  */
 
-#ifndef CAN_NETLINK_H
-#define CAN_NETLINK_H
+#ifndef _CAN_NETLINK_H
+#define _CAN_NETLINK_H
 
 #include <linux/types.h>
 
@@ -31,15 +40,15 @@ struct can_bittiming {
 };
 
 /*
- * CAN harware-dependent bit-timing constant
+ * CAN hardware-dependent bit-timing constant
  *
  * Used for calculating and checking bit-timing parameters
  */
 struct can_bittiming_const {
 	char name[16];		/* Name of the CAN controller hardware */
-	__u32 tseg1_min;	/* Time segement 1 = prop_seg + phase_seg1 */
+	__u32 tseg1_min;	/* Time segment 1 = prop_seg + phase_seg1 */
 	__u32 tseg1_max;
-	__u32 tseg2_min;	/* Time segement 2 = phase_seg2 */
+	__u32 tseg2_min;	/* Time segment 2 = phase_seg2 */
 	__u32 tseg2_max;
 	__u32 sjw_max;		/* Synchronisation jump width */
 	__u32 brp_min;		/* Bit-rate prescaler */
@@ -84,10 +93,13 @@ struct can_ctrlmode {
 };
 
 #define CAN_CTRLMODE_LOOPBACK		0x01	/* Loopback mode */
-#define CAN_CTRLMODE_LISTENONLY		0x02 	/* Listen-only mode */
+#define CAN_CTRLMODE_LISTENONLY		0x02	/* Listen-only mode */
 #define CAN_CTRLMODE_3_SAMPLES		0x04	/* Triple sampling mode */
 #define CAN_CTRLMODE_ONE_SHOT		0x08	/* One-Shot mode */
 #define CAN_CTRLMODE_BERR_REPORTING	0x10	/* Bus-error reporting */
+#define CAN_CTRLMODE_FD			0x20	/* CAN FD mode */
+#define CAN_CTRLMODE_PRESUME_ACK	0x40	/* Ignore missing CAN ACKs */
+#define CAN_CTRLMODE_FD_NON_ISO		0x80	/* CAN FD in non-ISO mode */
 
 /*
  * CAN device statistics
@@ -114,9 +126,19 @@ enum {
 	IFLA_CAN_RESTART_MS,
 	IFLA_CAN_RESTART,
 	IFLA_CAN_BERR_COUNTER,
+	IFLA_CAN_DATA_BITTIMING,
+	IFLA_CAN_DATA_BITTIMING_CONST,
+	IFLA_CAN_TERMINATION,
+	IFLA_CAN_TERMINATION_CONST,
+	IFLA_CAN_BITRATE_CONST,
+	IFLA_CAN_DATA_BITRATE_CONST,
+	IFLA_CAN_BITRATE_MAX,
 	__IFLA_CAN_MAX
 };
 
 #define IFLA_CAN_MAX	(__IFLA_CAN_MAX - 1)
 
-#endif /* CAN_NETLINK_H */
+/* u16 termination range: 1..65535 Ohms */
+#define CAN_TERMINATION_DISABLED 0
+
+#endif /* !_UAPI_CAN_NETLINK_H */

--- a/include/netlink/route/link/can.h
+++ b/include/netlink/route/link/can.h
@@ -53,6 +53,19 @@ extern int rtnl_link_can_get_ctrlmode(struct rtnl_link *, uint32_t *);
 extern int rtnl_link_can_set_ctrlmode(struct rtnl_link *, uint32_t);
 extern int rtnl_link_can_unset_ctrlmode(struct rtnl_link *, uint32_t);
 
+extern int rtnl_link_can_get_data_bt_const(struct rtnl_link *,
+														 struct can_bittiming_const *);
+extern int rtnl_link_can_get_data_bittiming(struct rtnl_link *,
+														  struct can_bittiming *);
+extern int rtnl_link_can_set_data_bittiming(struct rtnl_link *,
+														  struct can_bittiming *);
+
+extern int rtnl_link_can_get_data_bitrate(struct rtnl_link *, uint32_t *);
+extern int rtnl_link_can_set_data_bitrate(struct rtnl_link *, uint32_t);
+
+extern int rtnl_link_can_get_data_sample_point(struct rtnl_link *, uint32_t *);
+extern int rtnl_link_can_set_data_sample_point(struct rtnl_link *, uint32_t);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/route/link/can.c
+++ b/lib/route/link/can.c
@@ -34,25 +34,30 @@
 #include <linux/can/netlink.h>
 
 /** @cond SKIP */
-#define CAN_HAS_BITTIMING		(1<<0)
-#define CAN_HAS_BITTIMING_CONST		(1<<1)
-#define CAN_HAS_CLOCK			(1<<2)
-#define CAN_HAS_STATE			(1<<3)
-#define CAN_HAS_CTRLMODE		(1<<4)
-#define CAN_HAS_RESTART_MS		(1<<5)
-#define CAN_HAS_RESTART			(1<<6)
-#define CAN_HAS_BERR_COUNTER		(1<<7)
+#define CAN_HAS_BITTIMING					(1<<0)
+#define CAN_HAS_BITTIMING_CONST			(1<<1)
+#define CAN_HAS_CLOCK						(1<<2)
+#define CAN_HAS_STATE						(1<<3)
+#define CAN_HAS_CTRLMODE					(1<<4)
+#define CAN_HAS_RESTART_MS					(1<<5)
+#define CAN_HAS_RESTART						(1<<6)
+#define CAN_HAS_BERR_COUNTER				(1<<7)
+#define CAN_HAS_DATA_BITTIMING			(1<<8)
+#define CAN_HAS_DATA_BITTIMING_CONST	(1<<9)
+
 
 struct can_info {
-	uint32_t			ci_state;
-	uint32_t			ci_restart;
-	uint32_t			ci_restart_ms;
-	struct can_ctrlmode		ci_ctrlmode;
-	struct can_bittiming		ci_bittiming;
+	uint32_t							ci_state;
+	uint32_t							ci_restart;
+	uint32_t							ci_restart_ms;
+	struct can_ctrlmode			ci_ctrlmode;
+	struct can_bittiming			ci_bittiming;
 	struct can_bittiming_const	ci_bittiming_const;
-	struct can_clock		ci_clock;
+	struct can_clock				ci_clock;
 	struct can_berr_counter		ci_berr_counter;
-	uint32_t			ci_mask;
+	uint32_t							ci_mask;
+   struct can_bittiming			ci_data_bittiming;
+   struct can_bittiming_const	ci_data_bittiming_const;
 };
 
 /** @endcond */
@@ -67,6 +72,9 @@ static struct nla_policy can_policy[IFLA_CAN_MAX + 1] = {
 				= { .minlen = sizeof(struct can_bittiming_const) },
 	[IFLA_CAN_CLOCK]	= { .minlen = sizeof(struct can_clock) },
 	[IFLA_CAN_BERR_COUNTER]	= { .minlen = sizeof(struct can_berr_counter) },
+	[IFLA_CAN_DATA_BITTIMING]	= { .minlen = sizeof(struct can_bittiming) },
+   [IFLA_CAN_DATA_BITTIMING_CONST]
+				= { .minlen = sizeof(struct can_bittiming_const) },
 };
 
 static int can_alloc(struct rtnl_link *link)
@@ -147,6 +155,18 @@ static int can_parse(struct rtnl_link *link, struct nlattr *data,
 		nla_memcpy(&ci->ci_berr_counter, tb[IFLA_CAN_BERR_COUNTER],
 			   sizeof(ci->ci_berr_counter));
 		ci->ci_mask |= CAN_HAS_BERR_COUNTER;
+	}
+
+	if (tb[IFLA_CAN_DATA_BITTIMING]) {
+		nla_memcpy(&ci->ci_data_bittiming, tb[IFLA_CAN_DATA_BITTIMING],
+			   sizeof(ci->ci_data_bittiming));
+		ci->ci_mask |= CAN_HAS_DATA_BITTIMING;
+	}
+
+	if (tb[IFLA_CAN_DATA_BITTIMING_CONST]) {
+		nla_memcpy(&ci->ci_data_bittiming_const, tb[IFLA_CAN_DATA_BITTIMING_CONST],
+					  sizeof(ci->ci_data_bittiming_const));
+		ci->ci_mask |= CAN_HAS_DATA_BITTIMING_CONST;
 	}
 
 	err = 0;
@@ -303,32 +323,40 @@ static int can_put_attrs(struct nl_msg *msg, struct rtnl_link *link)
 		return -NLE_MSGSIZE;
 
 	if (ci->ci_mask & CAN_HAS_RESTART)
-		NLA_PUT_U32(msg, CAN_HAS_RESTART, ci->ci_restart);
+		NLA_PUT_U32(msg, IFLA_CAN_RESTART, ci->ci_restart);
 
-	if (ci->ci_mask & CAN_HAS_RESTART_MS)
-		NLA_PUT_U32(msg, CAN_HAS_RESTART_MS, ci->ci_restart_ms);
+	if (ci->ci_mask & CAN_HAS_RESTART_MS) {
+		NLA_PUT_U32(msg, IFLA_CAN_RESTART_MS, ci->ci_restart_ms);
+    }
 
 	if (ci->ci_mask & CAN_HAS_CTRLMODE)
-		NLA_PUT(msg, CAN_HAS_CTRLMODE, sizeof(ci->ci_ctrlmode),
+		NLA_PUT(msg, IFLA_CAN_CTRLMODE, sizeof(ci->ci_ctrlmode),
 			&ci->ci_ctrlmode);
 
 	if (ci->ci_mask & CAN_HAS_BITTIMING)
-		NLA_PUT(msg, CAN_HAS_BITTIMING, sizeof(ci->ci_bittiming),
+		NLA_PUT(msg, IFLA_CAN_BITTIMING, sizeof(ci->ci_bittiming),
 			&ci->ci_bittiming);
 
 	if (ci->ci_mask & CAN_HAS_BITTIMING_CONST)
-		NLA_PUT(msg, CAN_HAS_BITTIMING_CONST,
+		NLA_PUT(msg, IFLA_CAN_BITTIMING_CONST,
 			sizeof(ci->ci_bittiming_const),
 			&ci->ci_bittiming_const);
 
 	if (ci->ci_mask & CAN_HAS_CLOCK)
-		NLA_PUT(msg, CAN_HAS_CLOCK, sizeof(ci->ci_clock),
+		NLA_PUT(msg, IFLA_CAN_CLOCK, sizeof(ci->ci_clock),
 			&ci->ci_clock);
+
+	if (ci->ci_mask & CAN_HAS_DATA_BITTIMING)
+		NLA_PUT(msg, IFLA_CAN_DATA_BITTIMING, sizeof(ci->ci_data_bittiming),
+			&ci->ci_data_bittiming);
+
+	if (ci->ci_mask & CAN_HAS_DATA_BITTIMING_CONST)
+		NLA_PUT(msg, IFLA_CAN_DATA_BITTIMING_CONST, sizeof(ci->ci_data_bittiming_const),
+				  &ci->ci_data_bittiming_const);
 
 	nla_nest_end(msg, data);
 
 nla_put_failure:
-
 	return 0;
 }
 
@@ -489,7 +517,7 @@ int rtnl_link_can_berr(struct rtnl_link *link, struct can_berr_counter *berr)
 }
 
 /**
- * Get CAN harware-dependent bit-timing constant
+ * Get CAN hardware-dependent bit-timing constant
  * @arg link            Link object
  * @arg bt_const	Bit-timing constant
  *
@@ -747,6 +775,161 @@ int rtnl_link_can_unset_ctrlmode(struct rtnl_link *link, uint32_t ctrlmode)
 	return 0;
 }
 
+/**
+ * Get CAN FD hardware-dependent data bit-timing constant
+ * @arg link				Link object
+ * @arg data_bt_const	CAN FD data bit-timing constant
+ *
+ * @return 0 on success or a negative error code
+ */
+int rtnl_link_can_get_data_bt_const(struct rtnl_link *link,
+												struct can_bittiming_const *data_bt_const)
+{
+	struct can_info *ci = link->l_info;
+
+	IS_CAN_LINK_ASSERT(link);
+	if (!data_bt_const)
+		return -NLE_INVAL;
+
+	if (ci->ci_mask & CAN_HAS_DATA_BITTIMING_CONST)
+		*data_bt_const = ci->ci_data_bittiming_const;
+	else
+		return -NLE_AGAIN;
+
+	return 0;
+}
+
+/**
+ * Get CAN FD device data bit-timing
+ * @arg link					Link object
+ * @arg data_bit_timing		CAN FD data bit-timing
+ *
+ * @return 0 on success or a negative error code
+ */
+int rtnl_link_can_get_data_bittiming(struct rtnl_link *link,
+												 struct can_bittiming *data_bit_timing)
+{
+	struct can_info *ci = link->l_info;
+
+	IS_CAN_LINK_ASSERT(link);
+	if (!data_bit_timing)
+		return -NLE_INVAL;
+
+	if (ci->ci_mask & CAN_HAS_DATA_BITTIMING)
+		*data_bit_timing = ci->ci_data_bittiming;
+	else
+		return -NLE_AGAIN;
+
+	return 0;
+}
+
+/**
+ * Set CAN FD device data bit-timing
+ * @arg link					Link object
+ * @arg data_bit_timing		CAN FD data bit-timing
+ *
+ * @return 0 on success or a negative error code
+ */
+int rtnl_link_can_set_data_bittiming(struct rtnl_link *link,
+												 struct can_bittiming *data_bit_timing)
+{
+	struct can_info *ci = link->l_info;
+
+	IS_CAN_LINK_ASSERT(link);
+	if (!data_bit_timing)
+		return -NLE_INVAL;
+
+	ci->ci_data_bittiming = *data_bit_timing;
+	ci->ci_mask |= CAN_HAS_DATA_BITTIMING;
+
+	return 0;
+}
+
+/**
+ * Get CAN FD device data bit-timing
+ * @arg link            Link object
+ * @arg data_bitrate		CAN FD data bitrate
+ *
+ * @return 0 on success or a negative error code
+ */
+int rtnl_link_can_get_data_bitrate(struct rtnl_link *link, uint32_t *data_bitrate)
+{
+	struct can_info *ci = link->l_info;
+
+	IS_CAN_LINK_ASSERT(link);
+	if (!data_bitrate)
+		return -NLE_INVAL;
+
+	if (ci->ci_mask & CAN_HAS_DATA_BITTIMING)
+		*data_bitrate = ci->ci_data_bittiming.bitrate;
+	else
+		return -NLE_AGAIN;
+
+	return 0;
+}
+
+/**
+ * Set CAN FD device data bit-rate
+ * @arg link            Link object
+ * @arg data_bitrate    CAN FD data bitrate
+ *
+ * @return 0 on success or a negative error code
+ */
+int rtnl_link_can_set_data_bitrate(struct rtnl_link *link, uint32_t data_bitrate)
+{
+	struct can_info *ci = link->l_info;
+
+	IS_CAN_LINK_ASSERT(link);
+
+	ci->ci_data_bittiming.bitrate = data_bitrate;
+	ci->ci_mask |= CAN_HAS_DATA_BITTIMING;
+
+	return 0;
+}
+
+/**
+ * Get CAN FD device data sample point
+ * @arg link	Link object
+ * @arg sp		CAN FD sample point
+ *
+ * @return 0 on success or a negative error code
+ */
+int rtnl_link_can_get_data_sample_point(struct rtnl_link *link, uint32_t *sp)
+{
+	struct can_info *ci = link->l_info;
+
+	IS_CAN_LINK_ASSERT(link);
+	if (!sp)
+		return -NLE_INVAL;
+
+	if (ci->ci_mask & CAN_HAS_DATA_BITTIMING)
+		*sp = ci->ci_data_bittiming.sample_point;
+	else
+		return -NLE_AGAIN;
+
+	return 0;
+}
+
+/**
+ * Set CAN FD device data sample point
+ * @arg link	Link object
+ * @arg sp		CAN FD sample point
+ *
+ * @return 0 on success or a negative error code
+ */
+int rtnl_link_can_set_data_sample_point(struct rtnl_link *link, uint32_t sp)
+{
+	struct can_info *ci = link->l_info;
+
+	IS_CAN_LINK_ASSERT(link);
+
+	ci->ci_data_bittiming.sample_point = sp;
+	ci->ci_mask |= CAN_HAS_DATA_BITTIMING;
+
+	return 0;
+}
+
+
 /** @} */
 
 /**
@@ -760,6 +943,9 @@ static const struct trans_tbl can_ctrlmode[] = {
 	__ADD(CAN_CTRLMODE_3_SAMPLES, triple-sampling),
 	__ADD(CAN_CTRLMODE_ONE_SHOT, one-shot),
 	__ADD(CAN_CTRLMODE_BERR_REPORTING, berr-reporting),
+	__ADD(CAN_CTRLMODE_FD, fd),
+	__ADD(CAN_CTRLMODE_PRESUME_ACK, presume-ack),
+	__ADD(CAN_CTRLMODE_FD_NON_ISO, fd-non-iso),
 };
 
 char *rtnl_link_can_ctrlmode2str(int ctrlmode, char *buf, size_t len)


### PR DESCRIPTION
This PR contains the following CAN related fixes:

- Solved a bug that made it impossible to set any other settings than IFLA_CAN_BITTIMING. The internal bit mask values were used instead of the ones in the IFLA_CAN_* enum, causing the kernel to not understand.
- Added CAN FD support, analog to the non FD interfaces.
- New functions allow speed parameters to be set and CAN FD to be enabled through ctrlmode:s.